### PR TITLE
FIX:  Structuring Ansible Playbooks > Using Tags > 05 > include_tasks

### DIFF
--- a/Structuring Ansible Playbooks/Using Tags/05/include_tasks.yaml
+++ b/Structuring Ansible Playbooks/Using Tags/05/include_tasks.yaml
@@ -3,6 +3,8 @@
 
 - debug:
     msg: Include tasks executed
+  tags:
+    - include_tasks
 
 # Three dots indicate the end of a YAML document
 ...


### PR DESCRIPTION
FIX:  Structuring Ansible Playbooks > Using Tags > 05 > include_tasks.yaml so that tasks within that file execute with:  ansible-playbook include_import_playbook.yaml --tags "include_tasks"
