### PR TITLE
Fix numbering

### DIFF
--- a/Ansible Playbooks, Introduction/YAML/19/test.yaml
+++ b/Ansible Playbooks, Introduction/YAML/19/test.yaml
@@ -6,7 +6,7 @@ example_dictionary_1:
     - 1
     - 2
     - 3
-  - example_dictionary_2:
+  - example_dictionary_3:
     - 4
     - 5
     - 6


### PR DESCRIPTION
There probably should not be two items named:

`example_dictionary_2`
    