### PR TITLE
Remove future import

### DIFF
--- a/Ansible Playbooks, Deep Dive/Dynamic Inventories/01/inventory.py
+++ b/Ansible Playbooks, Deep Dive/Dynamic Inventories/01/inventory.py
@@ -4,9 +4,6 @@
 Dynamic inventory for Ansible in Python
 '''
 
-# Use print functionality from Python 3 for compatibility
-from __future__ import print_function
-
 import argparse
 import logging
 

--- a/Ansible Playbooks, Deep Dive/Dynamic Inventories/02/inventory.py
+++ b/Ansible Playbooks, Deep Dive/Dynamic Inventories/02/inventory.py
@@ -4,9 +4,6 @@
 Dynamic inventory for Ansible in Python
 '''
 
-# Use print functionality from Python 3 for compatibility
-from __future__ import print_function
-
 import argparse
 import logging
 

--- a/Ansible Playbooks, Deep Dive/Dynamic Inventories/03/inventory.py
+++ b/Ansible Playbooks, Deep Dive/Dynamic Inventories/03/inventory.py
@@ -4,9 +4,6 @@
 Dynamic inventory for Ansible in Python
 '''
 
-# Use print functionality from Python 3 for compatibility
-from __future__ import print_function
-
 import argparse
 import logging
 

--- a/Ansible Playbooks, Deep Dive/Dynamic Inventories/04/inventory.py
+++ b/Ansible Playbooks, Deep Dive/Dynamic Inventories/04/inventory.py
@@ -4,9 +4,6 @@
 Dynamic inventory for Ansible in Python
 '''
 
-# Use print functionality from Python 3 for compatibility
-from __future__ import print_function
-
 import argparse
 import logging
 


### PR DESCRIPTION
Since we are using Python3 (as we should!), there is no need to
import the `print` function.