### PR TITLE
Update python-dnspython package

### DIFF
--- a/Ansible Playbooks, Deep Dive/Blocks/03/blocks_playbook.yaml
+++ b/Ansible Playbooks, Deep Dive/Blocks/03/blocks_playbook.yaml
@@ -18,9 +18,9 @@
           package:
             name: patch
 
-        - name: Install python-dnspython
+        - name: Install python3-dnspython
           package:
-            name: python-dnspython
+            name: python3-dnspython
 
       rescue:
         - name: Rollback patch
@@ -28,9 +28,9 @@
             name: patch
             state: absent
 
-        - name: Rollback python-dnspython
+        - name: Rollback python3-dnspython
           package:
-            name: python-dnspython
+            name: python3-dnspython
             state: absent
 
       always:


### PR DESCRIPTION
When I was running my playbook the installation failed for all the hosts. By looking closely looks like the package name changed in this new Ubuntu version (jammy) To python-dnspython -> python3-dnspython.
Probably because python2 was deprecated and python3 is now the official one.