### PR TITLE
update to correct centos version for current containers

### DIFF
--- a/Ansible Playbooks, Deep Dive/Register and When/04/register_playbook.yaml
+++ b/Ansible Playbooks, Deep Dive/Register and When/04/register_playbook.yaml
@@ -13,7 +13,7 @@
   tasks:
     - name: Exploring register
       command: hostname -s
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "8"
+      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "9"
 
 # Three dots indicate the end of a YAML document
 ...

--- a/Ansible Playbooks, Deep Dive/Register and When/05/register_playbook.yaml
+++ b/Ansible Playbooks, Deep Dive/Register and When/05/register_playbook.yaml
@@ -13,7 +13,7 @@
   tasks:
     - name: Exploring register
       command: hostname -s
-      when: ( ansible_distribution == "CentOS" and ansible_distribution_major_version == "8" ) or
+      when: ( ansible_distribution == "CentOS" and ansible_distribution_major_version == "9" ) or
             ( ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "22" )
 
 # Three dots indicate the end of a YAML document


### PR DESCRIPTION
some of the register labs were referencing centos 8, but the containers are centos 9 now.

